### PR TITLE
Add outer window scroll option

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -388,7 +388,8 @@ Terminal.defaults = {
   // escapeKey: null,
   debug: false,
   useStyle: false,
-  allowKeyPaste: false
+  allowKeyPaste: false,
+  allowOuterScroll: false
 };
 
 Terminal.options = {};
@@ -1020,13 +1021,20 @@ Terminal.prototype.bindMouse = function() {
   //  on(self.document, 'mousemove', sendMove);
   //}
 
+  // Does not cancel event while scroll to top/bottom
+  function shouldCancel(){
+      return self.options.allowOuterScroll && !(self.ydisp >= self.lines.length - self.rows || self.ydisp == 0);
+  }
+
   on(el, wheelEvent, function(ev) {
     if (!self.mouseEvents) return;
     if (self.x10Mouse
         || self.vt300Mouse
         || self.decLocator) return;
     sendButton(ev);
-    return cancel(ev);
+    if(shouldCancel()){
+        return cancel(ev);
+    }
   });
 
   // allow mousewheel scrolling in
@@ -1039,7 +1047,9 @@ Terminal.prototype.bindMouse = function() {
     } else {
       self.scrollDisp(ev.wheelDeltaY > 0 ? -5 : 5);
     }
-    return cancel(ev);
+    if(shouldCancel()){
+        return cancel(ev);
+    }
   });
 };
 
@@ -4682,3 +4692,4 @@ if (typeof module !== 'undefined') {
 }).call(function() {
   return this || (typeof window !== 'undefined' ? window : global);
 }());
+


### PR DESCRIPTION
Add an option that allows the browser window scrolls by mousewheel event when the terminal window is scrolled to the end of top or bottom
