### PR TITLE
Fix {fore,back}ground when passing 18 colors

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -168,7 +168,7 @@ function Terminal(options) {
     options.colors = options.colors.slice(0, -2).concat(
       Terminal._colors.slice(8, -2), options.colors.slice(-2));
   } else if (options.colors.length === 18) {
-    options.colors = options.colors.concat(
+    options.colors = options.colors.slice(0, -2).concat(
       Terminal._colors.slice(16, -2), options.colors.slice(-2));
   }
   this.colors = options.colors;


### PR DESCRIPTION
When you pass 18 colors, you expect the last two of them to be the background and the foreground. However, in the current implementation there is a bug with the filling to the 256th color, so the background and foreground colors end up being 2 places off of where you look for them.

Here is a little patch to `example/index.html` to demonstrate the problem.

``` diff
diff --git i/example/index.html w/example/index.html
index ccac5f5..b93269e 100644
--- i/example/index.html
+++ w/example/index.html
@@ -37,6 +37,26 @@
       var term = new Terminal({
         cols: 80,
         rows: 24,
+        colors: [
+          '#000000',
+          '#cd0000',
+          '#00cd00',
+          '#cdcd00',
+          '#0000ee',
+          '#cd00cd',
+          '#00cdcd',
+          '#e5e5e5',
+          '#7f7f7f',
+          '#ff0000',
+          '#00ff00',
+          '#ffff00',
+          '#5c5cff',
+          '#ff00ff',
+          '#00ffff',
+          '#ffffff',
+          '#ffffff',
+          '#000000'
+        ],
         useStyle: true,
         screenKeys: true
       });
```
