### PR TITLE
Locali(s)(z)ed keyboard support for 3rd level characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 A full xterm clone written in javascript. Used by [**Cloud 9v2**](https://github.com/exsilium/cloud9).
 
-Maintenance fork to keep compatibility with existing implementation. Backporting crucial fixes from [sourcelair/xterm.js](https://github.com/sourcelair/xterm.js)
+Maintenance fork to keep compatibility with existing implementation. Backporting crucial fixes from [sourcelair/xterm.js](https://github.com/sourcelair/xterm.js). Project focus is on usability and compatibility - keeping it simple.
 
 * Fix cross platform input problems [sourcelair/xterm.js#60](https://github.com/sourcelair/xterm.js/pull/60);
 * Textarea used for DOM event capturing (`compositionstart`, `-update`, `-end`);
 * Enhancements made in `evaluateKeyEscapeSequence`;
+* Killed the various modes: prefixMode; selectMode; visualMode; searchMode - use tmux/screen instead
 
 ## License
 
-Copyright (c) 2014-2016, Sten Feldman (MIT License)
-Copyright (c) 2014-2016, SourceLair, Private Company (www.sourcelair.com) (MIT License)
-Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
+* Copyright (c) 2013-2016, Sten Feldman (MIT License)
+* Copyright (c) 2014-2016, SourceLair, Private Company (www.sourcelair.com) (MIT License)
+* Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)

--- a/README.md
+++ b/README.md
@@ -1,83 +1,15 @@
 # term.js
 
-A full xterm clone written in javascript. Used by
-[**tty.js**](https://github.com/chjj/tty.js).
+A full xterm clone written in javascript. Used by [**Cloud 9v2**](https://github.com/exsilium/cloud9).
 
-**⚠️ This project is no longer maintained ⚠️. For a maintained fork take a look at [sourcelair/xterm.js](https://github.com/sourcelair/xterm.js).**
+Maintenance fork to keep compatibility with existing implementation. Backporting crucial fixes from [sourcelair/xterm.js](https://github.com/sourcelair/xterm.js)
 
-## Example
-
-Server:
-
-``` js
-var term = require('term.js');
-app.use(term.middleware());
-...
-```
-
-Client:
-
-``` js
-window.addEventListener('load', function() {
-  var socket = io.connect();
-  socket.on('connect', function() {
-    var term = new Terminal({
-      cols: 80,
-      rows: 24,
-      screenKeys: true
-    });
-
-    term.on('data', function(data) {
-      socket.emit('data', data);
-    });
-
-    term.on('title', function(title) {
-      document.title = title;
-    });
-
-    term.open(document.body);
-
-    term.write('\x1b[31mWelcome to term.js!\x1b[m\r\n');
-
-    socket.on('data', function(data) {
-      term.write(data);
-    });
-
-    socket.on('disconnect', function() {
-      term.destroy();
-    });
-  });
-}, false);
-```
-
-## Tmux-like
-
-While term.js has always supported copy/paste using the mouse, it now also
-supports several keyboard based solutions for copy/paste.
-
-term.js includes a tmux-like selection mode (enabled with the `screenKeys`
-option) which makes copy and paste very simple. `Ctrl-A` enters `prefix` mode,
-from here you can type `Ctrl-V` to paste. Press `[` in prefix mode to enter
-selection mode. To select text press `v` (or `space`) to enter visual mode, use
-`hjkl` to navigate and create a selection, and press `Ctrl-C` to copy.
-
-`Ctrl-C` (in visual mode) and `Ctrl-V` (in prefix mode) should work in any OS
-for copy and paste. `y` (in visual mode) will work for copying only on X11
-systems. It will copy to the primary selection.
-
-Note: `Ctrl-C` will also work in prefix mode for the regular OS/browser
-selection. If you want to select text with your mouse and copy it to the
-clipboard, simply select the text and type `Ctrl-A + Ctrl-C`, and
-`Ctrl-A + Ctrl-V` to paste it.
-
-For mac users: consider `Ctrl` to be `Command/Apple` above.
-
-## Contribution and License Agreement
-
-If you contribute code to this project, you are implicitly allowing your code
-to be distributed under the MIT license. You are also implicitly verifying that
-all code is your original work. `</legalese>`
+* Fix cross platform input problems [sourcelair/xterm.js#60](https://github.com/sourcelair/xterm.js/pull/60);
+* Textarea used for DOM event capturing (`compositionstart`, `-update`, `-end`);
+* Enhancements made in `evaluateKeyEscapeSequence`;
 
 ## License
 
+Copyright (c) 2014-2016, Sten Feldman (MIT License)
+Copyright (c) 2014-2016, SourceLair, Private Company (www.sourcelair.com) (MIT License)
 Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ Maintenance fork to keep compatibility with existing implementation. Backporting
 * Enhancements made in `evaluateKeyEscapeSequence`;
 * Killed the various modes: prefixMode; selectMode; visualMode; searchMode - use tmux/screen instead
 
-# ToDo
-
-- [ ] PuTTY like select to Copy and Right-click to Paste functionality
-
 ## License
 
 * Copyright (c) 2013-2016, Sten Feldman (MIT License)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Maintenance fork to keep compatibility with existing implementation. Backporting
 * Enhancements made in `evaluateKeyEscapeSequence`;
 * Killed the various modes: prefixMode; selectMode; visualMode; searchMode - use tmux/screen instead
 
+# ToDo
+
+- [ ] PuTTY like select to Copy and Right-click to Paste functionality
+
 ## License
 
 * Copyright (c) 2013-2016, Sten Feldman (MIT License)

--- a/src/term.js
+++ b/src/term.js
@@ -444,7 +444,8 @@ Terminal.defaults = {
   scrollback: 1000,
   screenKeys: false,
   debug: false,
-  useStyle: false
+  useStyle: false,
+  kbLayout: 'us',
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -2810,7 +2811,84 @@ Terminal.prototype.keyDown = function(ev) {
         } else if (ev.keyCode >= 48 && ev.keyCode <= 57) {
           key = '\x1b' + (ev.keyCode - 48);
         }
-      }
+      } if (this['kbLayout'] != 'us' && ((this.isMac && ev.altKey) || (!this.isMac && ev.altKey && ev.ctrlKey))) {
+        // This is to support keyboards with third-level characters
+          if (this['kbLayout'] == 'ee') {
+          // Estonian
+            if(!this.isMac) {
+              if (ev.keyCode === 50) {
+                // AltGr-2 => @
+                key = String.fromCharCode(64);
+              } else if (ev.keyCode === 51) {
+                // AltGr-3 => £
+                key = String.fromCharCode(163);
+              } else if (ev.keyCode === 52) {
+                // AltGr-4 => $
+                key = String.fromCharCode(36);
+              } else if (ev.keyCode === 69) {
+                // AltGr-e => €
+                key = String.fromCharCode(8364);
+              } else if (ev.keyCode === 55) {
+                // AltGr-7 => {
+                key = String.fromCharCode(123);
+              } else if (ev.keyCode === 56) {
+                // AltGr-8 => [
+                key = String.fromCharCode(91);
+              } else if (ev.keyCode === 57) {
+                // AltGr-9 => ]
+                key = String.fromCharCode(93);
+              } else if (ev.keyCode === 48) {
+                // AltGr-0 => }
+                key = String.fromCharCode(125);
+              } else if (ev.keyCode === 189) {
+                // AltGr-+ => \
+                key = String.fromCharCode(92);
+              } else if (ev.keyCode === 226) {
+                // AltGr-< => |
+                key = String.fromCharCode(124);
+              }
+            } else if (this.isMac) {
+              if (ev.keyCode === 50) {
+                // Alt-2 => @
+                key = String.fromCharCode(64);
+              } else if (ev.keyCode === 51) {
+                // Alt-3 => £
+                key = String.fromCharCode(163);
+              } else if (ev.keyCode === 52) {
+                // Alt-4 => $
+                key = String.fromCharCode(36);
+              } else if (ev.keyCode === 219) {
+                if (ev.keyIdentifier === 'U+0037') {
+                  // Alt-7 => {
+                  key = String.fromCharCode(123);
+                } else if (ev.keyIdentifier === 'U+0038') {
+                  // Alt-8 => [
+                  key = String.fromCharCode(91);
+                }
+              } else if (ev.keyCode === 221) {
+                if (ev.keyIdentifier === 'U+0039') {
+                  // Alt-9 => ]
+                  key = String.fromCharCode(93);
+                } else if (ev.keyIdentifier === 'U+0030') {
+                  // Alt-0 => }
+                  key = String.fromCharCode(125);
+                }
+              } else if (ev.keyCode === 220) {
+                if (ev.keyIdentifier === 'U+002B') {
+                  // Alt-+ => \
+                  key = String.fromCharCode(92);
+                } else if (ev.keyIdentifier === 'U+003C') {
+                  // Alt-< => |
+                  key = String.fromCharCode(124);
+                }
+              }
+            }
+          } else if (['fr','de','uk','hr','si','ba','rs','be','pl','tr'].indexOf(this['kbLayout'] > -1)) {
+            console.log('Not implemented');
+          } else {
+            console.log('Unknown keyboard layout: %s', this['kbLayout']);
+          }
+        }
       break;
   }
 

--- a/src/term.js
+++ b/src/term.js
@@ -172,8 +172,7 @@ var normal = 0
   , osc = 3
   , charset = 4
   , dcs = 5
-  , ignore = 6
-  , UDK = { type: 'udk' };
+  , ignore = 6;
 
 /**
  * Terminal
@@ -234,13 +233,6 @@ function Terminal(options) {
   this.cols = options.cols || options.geometry[0];
   this.rows = options.rows || options.geometry[1];
 
-  // Act as though we are a node TTY stream:
-  this.setRawMode;
-  this.isTTY = true;
-  this.isRaw = true;
-  this.columns = this.cols;
-  this.rows = this.rows;
-
   if (options.handler) {
     this.on('data', options.handler);
   }
@@ -260,22 +252,9 @@ function Terminal(options) {
   // modes
   this.applicationKeypad = false;
   this.applicationCursor = false;
-  this.originMode = false;
   this.insertMode = false;
   this.wraparoundMode = false;
   this.normal = null;
-
-  // select modes
-  this.prefixMode = false;
-  this.selectMode = false;
-  this.visualMode = false;
-  this.searchMode = false;
-  this.searchDown;
-  this.entry = '';
-  this.entryPrefix = 'Search: ';
-  this._real;
-  this._selected;
-  this._textarea;
 
   // charset
   this.charset = null;
@@ -474,14 +453,6 @@ Terminal.prototype.focus = function() {
   if (this.sendFocus) this.send('\x1b[I');
   this.showCursor();
 
-  // try {
-  //   this.element.focus();
-  // } catch (e) {
-  //   ;
-  // }
-
-  // this.emit('focus');
-
   Terminal.focus = this;
 };
 
@@ -491,14 +462,6 @@ Terminal.prototype.blur = function() {
   this.cursorState = 0;
   this.refresh(this.y, this.y);
   if (this.sendFocus) this.send('\x1b[O');
-
-  // try {
-  //   this.element.blur();
-  // } catch (e) {
-  //   ;
-  // }
-
-  // this.emit('blur');
 
   Terminal.focus = null;
 };
@@ -519,8 +482,6 @@ Terminal.prototype.initGlobal = function() {
   Terminal.bindPaste(document);
 
   Terminal.bindKeys(document);
-
-  Terminal.bindCopy(document);
 
   if (this.useStyle) {
     Terminal.insertStyle(document, this.colors[256], this.colors[257]);
@@ -544,20 +505,14 @@ Terminal.prototype.clearSelection = function () {
  */
 
 Terminal.bindPaste = function(document) {
-  // This seems to work well for ctrl-V and middle-click,
-  // even without the contentEditable workaround.
-  var window = document.defaultView;
-  on(window, 'paste', function(ev) {
-    var term = Terminal.focus;
-    if (!term) return;
+  on(Terminal._textarea, 'paste', function(ev) {
+    ev.stopPropagation();
     if (ev.clipboardData) {
-      term.send(ev.clipboardData.getData('text/plain'));
-    } else if (term.context.clipboardData) {
-      term.send(term.context.clipboardData.getData('Text'));
+      var text = ev.clipboardData.getData('text/plain');
+      Terminal.focus.send(text);
+      Terminal._textarea.value = '';
+      return Terminal.cancel(ev);
     }
-    // Not necessary. Do it anyway for good measure.
-    term.element.contentEditable = 'inherit';
-    return cancel(ev);
   });
 };
 
@@ -655,51 +610,6 @@ Terminal.bindKeys = function(document) {
 };
 
 /**
- * Copy Selection w/ Ctrl-C (Select Mode)
- */
-
-Terminal.bindCopy = function(document) {
-  var window = document.defaultView;
-
-  // if (!('onbeforecopy' in document)) {
-  //   // Copies to *only* the clipboard.
-  //   on(window, 'copy', function fn(ev) {
-  //     var term = Terminal.focus;
-  //     if (!term) return;
-  //     if (!term._selected) return;
-  //     var text = term.grabText(
-  //       term._selected.x1, term._selected.x2,
-  //       term._selected.y1, term._selected.y2);
-  //     term.emit('copy', text);
-  //     ev.clipboardData.setData('text/plain', text);
-  //   });
-  //   return;
-  // }
-
-  // Copies to primary selection *and* clipboard.
-  // NOTE: This may work better on capture phase,
-  // or using the `beforecopy` event.
-  on(window, 'copy', function(ev) {
-    var term = Terminal.focus;
-    if (!term) return;
-    if (!term._selected) return;
-    var textarea = term.getCopyTextarea();
-    var text = term.grabText(
-      term._selected.x1, term._selected.x2,
-      term._selected.y1, term._selected.y2);
-    term.emit('copy', text);
-    textarea.focus();
-    textarea.textContent = text;
-    textarea.value = text;
-    textarea.setSelectionRange(0, text.length);
-    setTimeout(function() {
-      term.element.focus();
-      term.focus();
-    }, 1);
-  });
-};
-
-/**
  * Insert a default style
  */
 
@@ -728,19 +638,6 @@ Terminal.insertStyle = function(document, bg, fg) {
     + '  color: ' + bg + ';\n'
     + '  background: ' + fg + ';\n'
     + '}\n';
-
-  // var out = '';
-  // each(Terminal.colors, function(color, i) {
-  //   if (i === 256) {
-  //     out += '\n.term-bg-color-default { background-color: ' + color + '; }';
-  //   }
-  //   if (i === 257) {
-  //     out += '\n.term-fg-color-default { color: ' + color + '; }';
-  //   }
-  //   out += '\n.term-bg-color-' + i + ' { background-color: ' + color + '; }';
-  //   out += '\n.term-fg-color-' + i + ' { color: ' + color + '; }';
-  // });
-  // style.innerHTML += out + '\n';
 
   head.insertBefore(style, head.firstChild);
 };
@@ -864,11 +761,6 @@ Terminal.prototype.open = function(parent) {
       }
     });
 
-    // This causes slightly funky behavior.
-    // on(this.element, 'blur', function() {
-    //   self.blur();
-    // });
-
     on(this.element, 'mousedown', function() {
       self.focus();
     });
@@ -921,10 +813,6 @@ Terminal.prototype.open = function(parent) {
   }
 
   this.emit('open');
-};
-
-Terminal.prototype.setRawMode = function(value) {
-  this.isRaw = !!value;
 };
 
 // XTerm mouse events
@@ -1352,7 +1240,7 @@ Terminal.prototype.refresh = function(start, end) {
 
     if (y === this.y
         && this.cursorState
-        && (this.ydisp === this.ybase || this.selectMode)
+        && (this.ydisp === this.ybase)
         && !this.cursorHidden) {
       x = this.x;
     } else {
@@ -4935,102 +4823,6 @@ Terminal.prototype.deleteColumns = function() {
   this.maxRange();
 };
 
-/**
- * Prefix/Select/Visual/Search Modes
- */
-
-Terminal.prototype.enterPrefix = function() {
-  this.prefixMode = true;
-};
-
-Terminal.prototype.leavePrefix = function() {
-  this.prefixMode = false;
-};
-
-Terminal.prototype.enterSelect = function() {
-  this._real = {
-    x: this.x,
-    y: this.y,
-    ydisp: this.ydisp,
-    ybase: this.ybase,
-    cursorHidden: this.cursorHidden,
-    lines: this.copyBuffer(this.lines),
-    write: this.write
-  };
-  this.write = function() {};
-  this.selectMode = true;
-  this.visualMode = false;
-  this.cursorHidden = false;
-  this.refresh(this.y, this.y);
-};
-
-Terminal.prototype.leaveSelect = function() {
-  this.x = this._real.x;
-  this.y = this._real.y;
-  this.ydisp = this._real.ydisp;
-  this.ybase = this._real.ybase;
-  this.cursorHidden = this._real.cursorHidden;
-  this.lines = this._real.lines;
-  this.write = this._real.write;
-  delete this._real;
-  this.selectMode = false;
-  this.visualMode = false;
-  this.refresh(0, this.rows - 1);
-};
-
-Terminal.prototype.enterVisual = function() {
-  this._real.preVisual = this.copyBuffer(this.lines);
-  this.selectText(this.x, this.x, this.ydisp + this.y, this.ydisp + this.y);
-  this.visualMode = true;
-};
-
-Terminal.prototype.leaveVisual = function() {
-  this.lines = this._real.preVisual;
-  delete this._real.preVisual;
-  delete this._selected;
-  this.visualMode = false;
-  this.refresh(0, this.rows - 1);
-};
-
-Terminal.prototype.enterSearch = function(down) {
-  this.entry = '';
-  this.searchMode = true;
-  this.searchDown = down;
-  this._real.preSearch = this.copyBuffer(this.lines);
-  this._real.preSearchX = this.x;
-  this._real.preSearchY = this.y;
-
-  var bottom = this.ydisp + this.rows - 1;
-  for (var i = 0; i < this.entryPrefix.length; i++) {
-    //this.lines[bottom][i][0] = (this.defAttr & ~0x1ff) | 4;
-    //this.lines[bottom][i][1] = this.entryPrefix[i];
-    this.lines[bottom][i] = [
-      (this.defAttr & ~0x1ff) | 4,
-      this.entryPrefix[i]
-    ];
-  }
-
-  this.y = this.rows - 1;
-  this.x = this.entryPrefix.length;
-
-  this.refresh(this.rows - 1, this.rows - 1);
-};
-
-Terminal.prototype.leaveSearch = function() {
-  this.searchMode = false;
-
-  if (this._real.preSearch) {
-    this.lines = this._real.preSearch;
-    this.x = this._real.preSearchX;
-    this.y = this._real.preSearchY;
-    delete this._real.preSearch;
-    delete this._real.preSearchX;
-    delete this._real.preSearchY;
-  }
-
-  this.refresh(this.rows - 1, this.rows - 1);
-};
-
 Terminal.prototype.copyBuffer = function(lines) {
   var lines = lines || this.lines
     , out = [];
@@ -5086,120 +4878,6 @@ Terminal.prototype.copyText = function(text) {
     self.element.focus();
     self.focus();
   }, 1);
-};
-
-Terminal.prototype.selectText = function(x1, x2, y1, y2) {
-  var ox1
-    , ox2
-    , oy1
-    , oy2
-    , tmp
-    , x
-    , y
-    , xl
-    , attr;
-
-  if (this._selected) {
-    ox1 = this._selected.x1;
-    ox2 = this._selected.x2;
-    oy1 = this._selected.y1;
-    oy2 = this._selected.y2;
-
-    if (oy2 < oy1) {
-      tmp = ox2;
-      ox2 = ox1;
-      ox1 = tmp;
-      tmp = oy2;
-      oy2 = oy1;
-      oy1 = tmp;
-    }
-
-    if (ox2 < ox1 && oy1 === oy2) {
-      tmp = ox2;
-      ox2 = ox1;
-      ox1 = tmp;
-    }
-
-    for (y = oy1; y <= oy2; y++) {
-      x = 0;
-      xl = this.cols - 1;
-      if (y === oy1) {
-        x = ox1;
-      }
-      if (y === oy2) {
-        xl = ox2;
-      }
-      for (; x <= xl; x++) {
-        if (this.lines[y][x].old != null) {
-          //this.lines[y][x][0] = this.lines[y][x].old;
-          //delete this.lines[y][x].old;
-          attr = this.lines[y][x].old;
-          delete this.lines[y][x].old;
-          this.lines[y][x] = [attr, this.lines[y][x][1]];
-        }
-      }
-    }
-
-    y1 = this._selected.y1;
-    x1 = this._selected.x1;
-  }
-
-  y1 = Math.max(y1, 0);
-  y1 = Math.min(y1, this.ydisp + this.rows - 1);
-
-  y2 = Math.max(y2, 0);
-  y2 = Math.min(y2, this.ydisp + this.rows - 1);
-
-  this._selected = { x1: x1, x2: x2, y1: y1, y2: y2 };
-
-  if (y2 < y1) {
-    tmp = x2;
-    x2 = x1;
-    x1 = tmp;
-    tmp = y2;
-    y2 = y1;
-    y1 = tmp;
-  }
-
-  if (x2 < x1 && y1 === y2) {
-    tmp = x2;
-    x2 = x1;
-    x1 = tmp;
-  }
-
-  for (y = y1; y <= y2; y++) {
-    x = 0;
-    xl = this.cols - 1;
-    if (y === y1) {
-      x = x1;
-    }
-    if (y === y2) {
-      xl = x2;
-    }
-    for (; x <= xl; x++) {
-      //this.lines[y][x].old = this.lines[y][x][0];
-      //this.lines[y][x][0] &= ~0x1ff;
-      //this.lines[y][x][0] |= (0x1ff << 9) | 4;
-      attr = this.lines[y][x][0];
-      this.lines[y][x] = [
-        (attr & ~0x1ff) | ((0x1ff << 9) | 4),
-        this.lines[y][x][1]
-      ];
-      this.lines[y][x].old = attr;
-    }
-  }
-
-  y1 = y1 - this.ydisp;
-  y2 = y2 - this.ydisp;
-
-  y1 = Math.max(y1, 0);
-  y1 = Math.min(y1, this.rows - 1);
-
-  y2 = Math.max(y2, 0);
-  y2 = Math.min(y2, this.rows - 1);
-
-  //this.refresh(y1, y2);
-  this.refresh(0, this.rows - 1);
 };
 
 Terminal.prototype.grabText = function(x1, x2, y1, y2) {
@@ -5262,622 +4940,6 @@ Terminal.prototype.grabText = function(x1, x2, y1, y2) {
   }
 
   return out;
-};
-
-Terminal.prototype.keyPrefix = function(ev, key) {
-  if (key === 'k' || key === '&') {
-    this.destroy();
-  } else if (key === 'p' || key === ']') {
-    this.emit('request paste');
-  } else if (key === 'c') {
-    this.emit('request create');
-  } else if (key >= '0' && key <= '9') {
-    key = +key - 1;
-    if (!~key) key = 9;
-    this.emit('request term', key);
-  } else if (key === 'n') {
-    this.emit('request term next');
-  } else if (key === 'P') {
-    this.emit('request term previous');
-  } else if (key === ':') {
-    this.emit('request command mode');
-  } else if (key === '[') {
-    this.enterSelect();
-  }
-};
-
-Terminal.prototype.keySelect = function(ev, key) {
-  this.showCursor();
-
-  if (this.searchMode || key === 'n' || key === 'N') {
-    return this.keySearch(ev, key);
-  }
-
-  if (key === '\x04') { // ctrl-d
-    var y = this.ydisp + this.y;
-    if (this.ydisp === this.ybase) {
-      // Mimic vim behavior
-      this.y = Math.min(this.y + (this.rows - 1) / 2 | 0, this.rows - 1);
-      this.refresh(0, this.rows - 1);
-    } else {
-      this.scrollDisp((this.rows - 1) / 2 | 0);
-    }
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === '\x15') { // ctrl-u
-    var y = this.ydisp + this.y;
-    if (this.ydisp === 0) {
-      // Mimic vim behavior
-      this.y = Math.max(this.y - (this.rows - 1) / 2 | 0, 0);
-      this.refresh(0, this.rows - 1);
-    } else {
-      this.scrollDisp(-(this.rows - 1) / 2 | 0);
-    }
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === '\x06') { // ctrl-f
-    var y = this.ydisp + this.y;
-    this.scrollDisp(this.rows - 1);
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === '\x02') { // ctrl-b
-    var y = this.ydisp + this.y;
-    this.scrollDisp(-(this.rows - 1));
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === 'k' || key === '\x1b[A') {
-    var y = this.ydisp + this.y;
-    this.y--;
-    if (this.y < 0) {
-      this.y = 0;
-      this.scrollDisp(-1);
-    }
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y, this.y + 1);
-    }
-    return;
-  }
-
-  if (key === 'j' || key === '\x1b[B') {
-    var y = this.ydisp + this.y;
-    this.y++;
-    if (this.y >= this.rows) {
-      this.y = this.rows - 1;
-      this.scrollDisp(1);
-    }
-    if (this.visualMode) {
-      this.selectText(this.x, this.x, y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y - 1, this.y);
-    }
-    return;
-  }
-
-  if (key === 'h' || key === '\x1b[D') {
-    var x = this.x;
-    this.x--;
-    if (this.x < 0) {
-      this.x = 0;
-    }
-    if (this.visualMode) {
-      this.selectText(x, this.x, this.ydisp + this.y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y, this.y);
-    }
-    return;
-  }
-
-  if (key === 'l' || key === '\x1b[C') {
-    var x = this.x;
-    this.x++;
-    if (this.x >= this.cols) {
-      this.x = this.cols - 1;
-    }
-    if (this.visualMode) {
-      this.selectText(x, this.x, this.ydisp + this.y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y, this.y);
-    }
-    return;
-  }
-
-  if (key === 'v' || key === ' ') {
-    if (!this.visualMode) {
-      this.enterVisual();
-    } else {
-      this.leaveVisual();
-    }
-    return;
-  }
-
-  if (key === 'y') {
-    if (this.visualMode) {
-      var text = this.grabText(
-        this._selected.x1, this._selected.x2,
-        this._selected.y1, this._selected.y2);
-      this.copyText(text);
-      this.leaveVisual();
-      // this.leaveSelect();
-    }
-    return;
-  }
-
-  if (key === 'q' || key === '\x1b') {
-    if (this.visualMode) {
-      this.leaveVisual();
-    } else {
-      this.leaveSelect();
-    }
-    return;
-  }
-
-  if (key === 'w' || key === 'W') {
-    var ox = this.x;
-    var oy = this.y;
-    var oyd = this.ydisp;
-
-    var x = this.x;
-    var y = this.y;
-    var yb = this.ydisp;
-    var saw_space = false;
-
-    for (;;) {
-      var line = this.lines[yb + y];
-      while (x < this.cols) {
-        if (line[x][1] <= ' ') {
-          saw_space = true;
-        } else if (saw_space) {
-          break;
-        }
-        x++;
-      }
-      if (x >= this.cols) x = this.cols - 1;
-      if (x === this.cols - 1 && line[x][1] <= ' ') {
-        x = 0;
-        if (++y >= this.rows) {
-          y--;
-          if (++yb > this.ybase) {
-            yb = this.ybase;
-            x = this.x;
-            break;
-          }
-        }
-        continue;
-      }
-      break;
-    }
-
-    this.x = x, this.y = y;
-    this.scrollDisp(-this.ydisp + yb);
-
-    if (this.visualMode) {
-      this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === 'b' || key === 'B') {
-    var ox = this.x;
-    var oy = this.y;
-    var oyd = this.ydisp;
-
-    var x = this.x;
-    var y = this.y;
-    var yb = this.ydisp;
-
-    for (;;) {
-      var line = this.lines[yb + y];
-      var saw_space = x > 0 && line[x][1] > ' ' && line[x - 1][1] > ' ';
-      while (x >= 0) {
-        if (line[x][1] <= ' ') {
-          if (saw_space && (x + 1 < this.cols && line[x + 1][1] > ' ')) {
-            x++;
-            break;
-          } else {
-            saw_space = true;
-          }
-        }
-        x--;
-      }
-      if (x < 0) x = 0;
-      if (x === 0 && (line[x][1] <= ' ' || !saw_space)) {
-        x = this.cols - 1;
-        if (--y < 0) {
-          y++;
-          if (--yb < 0) {
-            yb++;
-            x = 0;
-            break;
-          }
-        }
-        continue;
-      }
-      break;
-    }
-
-    this.x = x, this.y = y;
-    this.scrollDisp(-this.ydisp + yb);
-
-    if (this.visualMode) {
-      this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === 'e' || key === 'E') {
-    var x = this.x + 1;
-    var y = this.y;
-    var yb = this.ydisp;
-    if (x >= this.cols) x--;
-
-    for (;;) {
-      var line = this.lines[yb + y];
-      while (x < this.cols) {
-        if (line[x][1] <= ' ') {
-          x++;
-        } else {
-          break;
-        }
-      }
-      while (x < this.cols) {
-        if (line[x][1] <= ' ') {
-          if (x - 1 >= 0 && line[x - 1][1] > ' ') {
-            x--;
-            break;
-          }
-        }
-        x++;
-      }
-      if (x >= this.cols) x = this.cols - 1;
-      if (x === this.cols - 1 && line[x][1] <= ' ') {
-        x = 0;
-        if (++y >= this.rows) {
-          y--;
-          if (++yb > this.ybase) {
-            yb = this.ybase;
-            break;
-          }
-        }
-        continue;
-      }
-      break;
-    }
-
-    this.x = x, this.y = y;
-    this.scrollDisp(-this.ydisp + yb);
-
-    if (this.visualMode) {
-      this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === '^' || key === '0') {
-    var ox = this.x;
-
-    if (key === '0') {
-      this.x = 0;
-    } else if (key === '^') {
-      var line = this.lines[this.ydisp + this.y];
-      var x = 0;
-      while (x < this.cols) {
-        if (line[x][1] > ' ') {
-          break;
-        }
-        x++;
-      }
-      if (x >= this.cols) x = this.cols - 1;
-      this.x = x;
-    }
-
-    if (this.visualMode) {
-      this.selectText(ox, this.x, this.ydisp + this.y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y, this.y);
-    }
-    return;
-  }
-
-  if (key === '$') {
-    var ox = this.x;
-    var line = this.lines[this.ydisp + this.y];
-    var x = this.cols - 1;
-    while (x >= 0) {
-      if (line[x][1] > ' ') {
-        if (this.visualMode && x < this.cols - 1) x++;
-        break;
-      }
-      x--;
-    }
-    if (x < 0) x = 0;
-    this.x = x;
-    if (this.visualMode) {
-      this.selectText(ox, this.x, this.ydisp + this.y, this.ydisp + this.y);
-    } else {
-      this.refresh(this.y, this.y);
-    }
-    return;
-  }
-
-  if (key === 'g' || key === 'G') {
-    var ox = this.x;
-    var oy = this.y;
-    var oyd = this.ydisp;
-    if (key === 'g') {
-      this.x = 0, this.y = 0;
-      this.scrollDisp(-this.ydisp);
-    } else if (key === 'G') {
-      this.x = 0, this.y = this.rows - 1;
-      this.scrollDisp(this.ybase);
-    }
-    if (this.visualMode) {
-      this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === 'H' || key === 'M' || key === 'L') {
-    var ox = this.x;
-    var oy = this.y;
-    if (key === 'H') {
-      this.x = 0, this.y = 0;
-    } else if (key === 'M') {
-      this.x = 0, this.y = this.rows / 2 | 0;
-    } else if (key === 'L') {
-      this.x = 0, this.y = this.rows - 1;
-    }
-    if (this.visualMode) {
-      this.selectText(ox, this.x, this.ydisp + oy, this.ydisp + this.y);
-    } else {
-      this.refresh(oy, oy);
-      this.refresh(this.y, this.y);
-    }
-    return;
-  }
-
-  if (key === '{' || key === '}') {
-    var ox = this.x;
-    var oy = this.y;
-    var oyd = this.ydisp;
-
-    var line;
-    var saw_full = false;
-    var found = false;
-    var first_is_space = -1;
-    var y = this.y + (key === '{' ? -1 : 1);
-    var yb = this.ydisp;
-    var i;
-
-    if (key === '{') {
-      if (y < 0) {
-        y++;
-        if (yb > 0) yb--;
-      }
-    } else if (key === '}') {
-      if (y >= this.rows) {
-        y--;
-        if (yb < this.ybase) yb++;
-      }
-    }
-
-    for (;;) {
-      line = this.lines[yb + y];
-
-      for (i = 0; i < this.cols; i++) {
-        if (line[i][1] > ' ') {
-          if (first_is_space === -1) {
-            first_is_space = 0;
-          }
-          saw_full = true;
-          break;
-        } else if (i === this.cols - 1) {
-          if (first_is_space === -1) {
-            first_is_space = 1;
-          } else if (first_is_space === 0) {
-            found = true;
-          } else if (first_is_space === 1) {
-            if (saw_full) found = true;
-          }
-          break;
-        }
-      }
-
-      if (found) break;
-
-      if (key === '{') {
-        y--;
-        if (y < 0) {
-          y++;
-          if (yb > 0) yb--;
-          else break;
-        }
-      } else if (key === '}') {
-        y++;
-        if (y >= this.rows) {
-          y--;
-          if (yb < this.ybase) yb++;
-          else break;
-        }
-      }
-    }
-
-    if (!found) {
-      if (key === '{') {
-        y = 0;
-        yb = 0;
-      } else if (key === '}') {
-        y = this.rows - 1;
-        yb = this.ybase;
-      }
-    }
-
-    this.x = 0, this.y = y;
-    this.scrollDisp(-this.ydisp + yb);
-
-    if (this.visualMode) {
-      this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-    }
-    return;
-  }
-
-  if (key === '/' || key === '?') {
-    if (!this.visualMode) {
-      this.enterSearch(key === '/');
-    }
-    return;
-  }
-
-  return false;
-};
-
-Terminal.prototype.keySearch = function(ev, key) {
-  if (key === '\x1b') {
-    this.leaveSearch();
-    return;
-  }
-
-  if (key === '\r' || (!this.searchMode && (key === 'n' || key === 'N'))) {
-    this.leaveSearch();
-
-    var entry = this.entry;
-
-    if (!entry) {
-      this.refresh(0, this.rows - 1);
-      return;
-    }
-
-    var ox = this.x;
-    var oy = this.y;
-    var oyd = this.ydisp;
-
-    var line;
-    var found = false;
-    var wrapped = false;
-    var x = this.x + 1;
-    var y = this.ydisp + this.y;
-    var yb, i;
-    var up = key === 'N'
-      ? this.searchDown
-      : !this.searchDown;
-
-    for (;;) {
-      line = this.lines[y];
-
-      while (x < this.cols) {
-        for (i = 0; i < entry.length; i++) {
-          if (x + i >= this.cols) break;
-          if (line[x + i][1] !== entry[i]) {
-            break;
-          } else if (line[x + i][1] === entry[i] && i === entry.length - 1) {
-            found = true;
-            break;
-          }
-        }
-        if (found) break;
-        x += i + 1;
-      }
-      if (found) break;
-
-      x = 0;
-
-      if (!up) {
-        y++;
-        if (y > this.ybase + this.rows - 1) {
-          if (wrapped) break;
-          // this.setMessage('Search wrapped. Continuing at TOP.');
-          wrapped = true;
-          y = 0;
-        }
-      } else {
-        y--;
-        if (y < 0) {
-          if (wrapped) break;
-          // this.setMessage('Search wrapped. Continuing at BOTTOM.');
-          wrapped = true;
-          y = this.ybase + this.rows - 1;
-        }
-      }
-    }
-
-    if (found) {
-      if (y - this.ybase < 0) {
-        yb = y;
-        y = 0;
-        if (yb > this.ybase) {
-          y = yb - this.ybase;
-          yb = this.ybase;
-        }
-      } else {
-        yb = this.ybase;
-        y -= this.ybase;
-      }
-
-      this.x = x, this.y = y;
-      this.scrollDisp(-this.ydisp + yb);
-
-      if (this.visualMode) {
-        this.selectText(ox, this.x, oy + oyd, this.ydisp + this.y);
-      }
-      return;
-    }
-
-    // this.setMessage("No matches found.");
-    this.refresh(0, this.rows - 1);
-
-    return;
-  }
-
-  if (key === '\b' || key === '\x7f') {
-    if (this.entry.length === 0) return;
-    var bottom = this.ydisp + this.rows - 1;
-    this.entry = this.entry.slice(0, -1);
-    var i = this.entryPrefix.length + this.entry.length;
-    //this.lines[bottom][i][1] = ' ';
-    this.lines[bottom][i] = [
-      this.lines[bottom][i][0],
-      ' '
-    ];
-    this.x--;
-    this.refresh(this.rows - 1, this.rows - 1);
-    this.refresh(this.y, this.y);
-    return;
-  }
-
-  if (key.length === 1 && key >= ' ' && key <= '~') {
-    var bottom = this.ydisp + this.rows - 1;
-    this.entry += key;
-    var i = this.entryPrefix.length + this.entry.length - 1;
-    //this.lines[bottom][i][0] = (this.defAttr & ~0x1ff) | 4;
-    //this.lines[bottom][i][1] = key;
-    this.lines[bottom][i] = [
-      (this.defAttr & ~0x1ff) | 4,
-      key
-    ];
-    this.x++;
-    this.refresh(this.rows - 1, this.rows - 1);
-    this.refresh(this.y, this.y);
-    return;
-  }
-
-  return false;
 };
 
 /**

--- a/src/term.js
+++ b/src/term.js
@@ -2713,6 +2713,12 @@ Terminal.prototype.evaluateKeyEscapeSequence = function (ev) {
         result.key = '\x1b[6~';
       }
       break;
+    case 86:
+      // Handle keyboard paste (Firefox & Chrome)
+      if ((this.isMac && ev.metaKey) || (!this.isMac && ev.ctrlKey)) {
+        Terminal._textarea.focus();
+      }
+      break;
     case 112:
       // F1-F12
       if (modifiers) {
@@ -2855,8 +2861,6 @@ Terminal.prototype.setgCharset = function(g, charset) {
 Terminal.prototype.keyPress = function(ev) {
   var key;
 
-  this.cancel(ev);
-
   if (ev.charCode) {
     key = ev.charCode;
   } else if (ev.which == null) {
@@ -2865,6 +2869,15 @@ Terminal.prototype.keyPress = function(ev) {
     key = ev.which;
   } else {
     return false;
+  }
+
+  // Don't cancel on paste and set focus on textarea (Safari)
+  if ((this.isMac && ev.metaKey && key === 118) ||
+      (!this.isMac && ev.ctrlKey && key === 118)) {
+    Terminal._textarea.focus();
+  }
+  else {
+    this.cancel(ev);
   }
 
   if (!key || (

--- a/src/term.js
+++ b/src/term.js
@@ -444,8 +444,7 @@ Terminal.defaults = {
   scrollback: 1000,
   screenKeys: false,
   debug: false,
-  useStyle: false,
-  kbLayout: 'us',
+  useStyle: false
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -2811,84 +2810,7 @@ Terminal.prototype.keyDown = function(ev) {
         } else if (ev.keyCode >= 48 && ev.keyCode <= 57) {
           key = '\x1b' + (ev.keyCode - 48);
         }
-      } if (this['kbLayout'] != 'us' && ((this.isMac && ev.altKey) || (!this.isMac && ev.altKey && ev.ctrlKey))) {
-        // This is to support keyboards with third-level characters
-          if (this['kbLayout'] == 'ee') {
-          // Estonian
-            if(!this.isMac) {
-              if (ev.keyCode === 50) {
-                // AltGr-2 => @
-                key = String.fromCharCode(64);
-              } else if (ev.keyCode === 51) {
-                // AltGr-3 => £
-                key = String.fromCharCode(163);
-              } else if (ev.keyCode === 52) {
-                // AltGr-4 => $
-                key = String.fromCharCode(36);
-              } else if (ev.keyCode === 69) {
-                // AltGr-e => €
-                key = String.fromCharCode(8364);
-              } else if (ev.keyCode === 55) {
-                // AltGr-7 => {
-                key = String.fromCharCode(123);
-              } else if (ev.keyCode === 56) {
-                // AltGr-8 => [
-                key = String.fromCharCode(91);
-              } else if (ev.keyCode === 57) {
-                // AltGr-9 => ]
-                key = String.fromCharCode(93);
-              } else if (ev.keyCode === 48) {
-                // AltGr-0 => }
-                key = String.fromCharCode(125);
-              } else if (ev.keyCode === 189) {
-                // AltGr-+ => \
-                key = String.fromCharCode(92);
-              } else if (ev.keyCode === 226) {
-                // AltGr-< => |
-                key = String.fromCharCode(124);
-              }
-            } else if (this.isMac) {
-              if (ev.keyCode === 50) {
-                // Alt-2 => @
-                key = String.fromCharCode(64);
-              } else if (ev.keyCode === 51) {
-                // Alt-3 => £
-                key = String.fromCharCode(163);
-              } else if (ev.keyCode === 52) {
-                // Alt-4 => $
-                key = String.fromCharCode(36);
-              } else if (ev.keyCode === 219) {
-                if (ev.keyIdentifier === 'U+0037') {
-                  // Alt-7 => {
-                  key = String.fromCharCode(123);
-                } else if (ev.keyIdentifier === 'U+0038') {
-                  // Alt-8 => [
-                  key = String.fromCharCode(91);
-                }
-              } else if (ev.keyCode === 221) {
-                if (ev.keyIdentifier === 'U+0039') {
-                  // Alt-9 => ]
-                  key = String.fromCharCode(93);
-                } else if (ev.keyIdentifier === 'U+0030') {
-                  // Alt-0 => }
-                  key = String.fromCharCode(125);
-                }
-              } else if (ev.keyCode === 220) {
-                if (ev.keyIdentifier === 'U+002B') {
-                  // Alt-+ => \
-                  key = String.fromCharCode(92);
-                } else if (ev.keyIdentifier === 'U+003C') {
-                  // Alt-< => |
-                  key = String.fromCharCode(124);
-                }
-              }
-            }
-          } else if (['fr','de','uk','hr','si','ba','rs','be','pl','tr'].indexOf(this['kbLayout'] > -1)) {
-            console.log('Not implemented');
-          } else {
-            console.log('Unknown keyboard layout: %s', this['kbLayout']);
-          }
-        }
+      }
       break;
   }
 

--- a/src/term.js
+++ b/src/term.js
@@ -707,6 +707,7 @@ Terminal.prototype.open = function(parent) {
   this.parent.appendChild(this.element);
 
   var textarea = document.createElement('textarea');
+  textarea.id = "termTextarea";
   textarea.style.position = 'absolute';
   textarea.style.left = '-32000px';
   textarea.style.top = '-32000px';


### PR DESCRIPTION
This patch includes support-beginnings for locali(s)(z)ation needed by countries where keyboard includes third-level characters.
Characters like @|{[]}\ are currently often not usable because they are mapped as 3rd level characters on different international keyboard layouts.
- kbLayout option introduced, which can be given during Terminal.call and changed even after, defaults to 'us';
- Placeholders for the following layouts:
  -> French (fr);
  -> German (de);
  -> UK (uk);
  -> South Slavic Latin countries - Croatia (hr),Slovenia (si), Bosnia and Herzegovina (ba), Serbia (rs);
  -> Belgium (be);
  -> Polish (pl);
  -> Turkish (tr);
- Placeholder keyboard layouts currently output "Not Implemented" to browser console;
- Estonian (ee) keyboard layout implementation for Windows (AltGr) and Mac (Alt);
- Should not break anything that was working before...

This patch will hopefully pave way for others to include their specific country layouts and solve issues like reported here: https://github.com/chjj/tty.js/issues/64
