### PR TITLE
Remove trailing `&nbsp;`s from each line

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -1313,7 +1313,7 @@ Terminal.prototype.refresh = function(start, end) {
       out += '</span>';
     }
     
-    out = out.replace(/(&nbsp;)+$/, '');
+    out = out.replace(/(&nbsp;)+$/, '&nbsp;');
 
     this.children[y].innerHTML = out;
   }


### PR DESCRIPTION
I've found that having a more easily resizable term.js requires not emitting so many `&nbsp;`s on every line. From what I can see, this change results in identical display and fewer characters written to the DOM, which makes it a positive, in my book.
