### PR TITLE
Different behaviour for Cmd+C, Cmd+v, etc on Mac

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2595,7 +2595,7 @@ Terminal.prototype.keyDown = function(ev) {
           // ^] - group sep
           key = String.fromCharCode(29);
         }
-      } else if ((!this.isMac && ev.altKey) || (this.isMac && ev.metaKey)) {
+      } else if (!this.isMac && ev.altKey) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           key = '\x1b' + String.fromCharCode(ev.keyCode + 32);
         } else if (ev.keyCode === 192) {
@@ -2603,6 +2603,8 @@ Terminal.prototype.keyDown = function(ev) {
         } else if (ev.keyCode >= 48 && ev.keyCode <= 57) {
           key = '\x1b' + (ev.keyCode - 48);
         }
+      } else if (this.isMac && ev.metaKey) {
+        return true;
       }
       break;
   }


### PR DESCRIPTION
It allows you to copy/paste any text from/into the terminal.
I suggest it, since this is the default behaviour in Terminal.app on Mac.
