### PR TITLE
Fix form TMUX-like mode for Mac

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2555,7 +2555,7 @@ Terminal.prototype.keyDown = function(ev) {
       break;
     default:
       // a-z and space
-      if (ev.ctrlKey) {
+      if (ev.ctrlKey  || this.isMac && ev.metaKey) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           // Ctrl-A
           if (this.screenKeys) {


### PR DESCRIPTION
Allowing Mac users to use Command key form Ctrl+A Ctrl+V/C, etc
