### PR TITLE
Fix issue chjj/tty.js#59

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -1902,12 +1902,16 @@ Terminal.prototype.write = function(data) {
 
           // CSI Pm m  Character Attributes (SGR).
           case 'm':
-            this.charAttributes(this.params);
+            if (!this.prefix) {
+              this.charAttributes(this.params);
+            }
             break;
 
           // CSI Ps n  Device Status Report (DSR).
           case 'n':
-            this.deviceStatus(this.params);
+            if (!this.prefix) {
+              this.deviceStatus(this.params);
+            }
             break;
 
           /**


### PR DESCRIPTION
^[[>##m and ^[[>##n are legal escape sequences, but were being parsed as if they were ^[[##m or ^[[##n. Added a test for prefix character ('>' is the only legal one)  

See http://invisible-island.net/xterm/ctlseqs/ctlseqs.html, code for CSI > P s ; P s m

If the prefix char is present, ignores the control sequence, since that code isn't implemented.
