### PR TITLE
Changed __defineGetter__ -> defineProperty in index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,15 +37,20 @@ term.middleware = function(options) {
 
 term.path = __dirname + '/../src/term.js';
 
-term.__defineGetter__('script', function() {
-  if (term._script) return term._script;
-  term.last = +new Date;
-  return term._script = require('fs').readFileSync(term.path, 'utf8');
+Object.defineProperty(term, 'script', {
+  get: function() {
+    if (term._script) return term._script;
+    term.last = +new Date;
+    return term._script = require('fs').readFileSync(term.path, 'utf8');
+  }
 });
 
-term.__defineGetter__('Terminal', function() {
-  if (term._Terminal) return term._Terminal;
-  return term._Terminal = require('../src/term');
+
+Object.defineProperty(term, 'Terminal', {
+  get: function() {
+    if (term._Terminal) return term._Terminal;
+    return term._Terminal = require('../src/term');
+  }
 });
 
 /**


### PR DESCRIPTION
`__defineGetter__` is [non-standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineGetter) and is not on a standards track.
