### PR TITLE
enable iPad fix on iPhone user agent

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -470,7 +470,7 @@ Terminal.prototype.initGlobal = function() {
 
   Terminal.bindCopy(document);
 
-  if (this.isIpad) {
+  if (this.isIpad || this.isIphone) {
     Terminal.fixIpad(document);
   }
 
@@ -692,6 +692,7 @@ Terminal.prototype.open = function(parent) {
   if (this.context.navigator && this.context.navigator.userAgent) {
     this.isMac = !!~this.context.navigator.userAgent.indexOf('Mac');
     this.isIpad = !!~this.context.navigator.userAgent.indexOf('iPad');
+    this.isIphone = !!~this.context.navigator.userAgent.indexOf('iPhone');
     this.isMSIE = !!~this.context.navigator.userAgent.indexOf('MSIE');
   }
 
@@ -729,7 +730,7 @@ Terminal.prototype.open = function(parent) {
   // to focus and paste behavior.
   on(this.element, 'focus', function() {
     self.focus();
-    if (self.isIpad) {
+    if (self.isIpad || self.isIphone) {
       Terminal._textarea.focus();
     }
   });


### PR DESCRIPTION
There is code for basic support for iPads. However, the current code only detects iPads, not iPhones. I ran into an issue where I needed to issue some commands into my tty.js setup and didn't have a computer nearby. This PR applies the same iPad fix to iPhones. (When using a soft keyboard, we have to focus a dummy input text to show the onscreen keyboard.) 

I tested with my iPhone 5 iOS 7.0.4 on Safari and it works great. 

I wasn't sure if we wanted to keep `isIpad` and `isIphone` separate or combine them into one variable called `isiOS` since iPad and iPhone get the same `fixIpad(document);`.
