### PR TITLE
Disable autocapitalize and autocorrect for iPad and iPhone devices

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -612,6 +612,8 @@ Terminal.fixIpad = function(document) {
   textarea.style.backgroundColor = 'transparent';
   textarea.style.borderStyle = 'none';
   textarea.style.outlineStyle = 'none';
+  textarea.autocapitalize='none';
+  textarea.autocorrect='off';
 
   document.getElementsByTagName('body')[0].appendChild(textarea);
 


### PR DESCRIPTION
This PR disables the `autocorrect` and `autocapitalize` [attributes](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/HTMLTags.html#//apple_ref/doc/uid/30001262-textarea) to the dummy `textarea`. 
