### PR TITLE
Saved cursor should stay on screen.

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2782,6 +2782,10 @@ Terminal.prototype.resize = function(x, y) {
   if (this.y >= y) this.y = y - 1;
   if (this.x >= x) this.x = x - 1;
 
+  // saved cursor should also stay on screen
+  if (this.savedY >= y) this.savedY = y - 1;
+  if (this.savedX >= x) this.savedX = x - 1;
+
   this.scrollTop = 0;
   this.scrollBottom = y - 1;
 


### PR DESCRIPTION
Term.js will crash by writing past this.lines if you save cursor position with a bigger terminal, then resize it to a smaller one, then try to restore the cursor position. To reproduce the problem:
1. assume the initial window size is 20
2. move cursor to the last row (y = 20)
3. enter into vim (savedY = 20)
4. resize terminal to 15 (rows = 15)
5. exit vim, which triggers cursor restore. this.y = this.savedY (y = 20, rows = 15)
6. terminal crashes when receiving new data

This patch makes sure that saved cursor position will stay on screen (as normal cursors do).
