### PR TITLE
Removed returnValue

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -5619,7 +5619,6 @@ function off(el, type, handler, capture) {
 
 function cancel(ev) {
   if (ev.preventDefault) ev.preventDefault();
-  ev.returnValue = false;
   if (ev.stopPropagation) ev.stopPropagation();
   ev.cancelBubble = true;
   return false;


### PR DESCRIPTION
Removed returnValue. Chrome says all the time:

```
event.returnValue is deprecated. Please use the standard event.preventDefault() instead.
```
