### PR TITLE
Removed stopPropogation, cancelBubble from term.js

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -5620,8 +5620,6 @@ function off(el, type, handler, capture) {
 function cancel(ev) {
   if (ev.preventDefault) ev.preventDefault();
   ev.returnValue = false;
-  if (ev.stopPropagation) ev.stopPropagation();
-  ev.cancelBubble = true;
   return false;
 }
 


### PR DESCRIPTION
Hi, I'm writing [cloud file manager](http://cloudcmd.io)
and using terminal, but it has no ability to run programs such **mc** or **vim**.
So I try adopt term.js to use it.

But I have a problem with cancelling event it **term.js**.
Listeners of Terminal is added to document, it's not  very good,
my listeners doesn't work because they are canceled in this code:

```
  if (ev.stopPropagation) ev.stopPropagation();
  ev.cancelBubble = true;
```

Is it realy needed?  Maybe there is some way to drop them?
Or add listeners to terminal element?

Thank you.
