### PR TITLE
Solved issue -- Need to trigger resize on first load to set rows

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2792,6 +2792,13 @@ Terminal.prototype.resize = function(x, y) {
   // screen buffer. just set it
   // to null for now.
   this.normal = null;
+
+  //Resizing terminal according to window size
+  Terminal.call(this, {
+    cols: this.cols,
+    rows: this.rows
+  });
+
 };
 
 Terminal.prototype.updateRange = function(y) {


### PR DESCRIPTION
@hhuuggoo  , @srossross 

Closes following issues 
#1 -> ContinuumIO/tty.js#1    Need to trigger resize on first load to set rows

```
Fix : Invoked terminal resizing function on terminal initialization that will open terminal as per window size. So output will be displayed as per window size.
```
#4 -> ContinuumIO/tty.js#4  less

```
Fix : Had a same issue with terminal size. Seems that solved after terminal resize.
```
