### PR TITLE
Added attribute to disable spellcheck on terminal div element

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -703,6 +703,7 @@ Terminal.prototype.open = function(parent) {
   this.element.className = 'terminal';
   this.element.style.outline = 'none';
   this.element.setAttribute('tabindex', 0);
+  this.element.setAttribute('spellcheck', 'false');
   this.element.style.backgroundColor = this.colors[256];
   this.element.style.color = this.colors[257];
 


### PR DESCRIPTION
In certain browsers (Chrome) spellcheck is applied to content editable elements.  This sets the "spellcheck" attribute to false on the main div element in order to prevent that happening.
