### PR TITLE
Fixed colors option handling or 18 colors.

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -168,7 +168,7 @@ function Terminal(options) {
     options.colors = options.colors.slice(0, -2).concat(
       Terminal._colors.slice(8, -2), options.colors.slice(-2));
   } else if (options.colors.length === 18) {
-    options.colors = options.colors.concat(
+    options.colors = options.colors.slice(0, -2).concat(
       Terminal._colors.slice(16, -2), options.colors.slice(-2));
   }
   this.colors = options.colors;


### PR DESCRIPTION
The handling of the colors option with a colors array of 18 elements was not properly splicing the colors into the internal 258 color array.  This change adds the missing slice() call like the one used on the 10 colors array.
