### PR TITLE
Fixed refreshBlink() method not disabling blink if cursorBlink is false

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -1344,8 +1344,8 @@ Terminal.prototype.startBlink = function() {
 };
 
 Terminal.prototype.refreshBlink = function() {
-  if (!this.cursorBlink) return;
   clearInterval(this._blink);
+  if (!this.cursorBlink) return;
   this._blink = setInterval(this._blinker, 500);
 };
 


### PR DESCRIPTION
If you call the refreshBlink(), I think it should disable blinking even if the cursorBlink property has been set to false rather than just leaving it alone.  If you disagree, feel free to reject this request.

It may also be wise to call showCursor before doing so, but I noticed at one point showCursor() called refreshBlink() and I did not want to create a potential future loop.
