### PR TITLE
let copy / paste work on mac

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2612,7 +2612,7 @@ Terminal.prototype.keyDown = function(ev) {
           // ^] - group sep
           key = String.fromCharCode(29);
         }
-      } else if ((!this.isMac && ev.altKey) || (this.isMac && ev.metaKey)) {
+      } else if (ev.altKey) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           key = '\x1b' + String.fromCharCode(ev.keyCode + 32);
         } else if (ev.keyCode === 192) {


### PR DESCRIPTION
this line breaks os level copy / paste (and possibly other things) for mac users by incorrectly assuming that the metaKey (aka command) should behave like alt. as others have pointed out mac keyboards actually do have alt keys, they just say "option" on them in slightly bigger letters ;)