### PR TITLE
Add support for ALT+. key combo

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2617,6 +2617,8 @@ Terminal.prototype.keyDown = function(ev) {
           key = '\x1b' + String.fromCharCode(ev.keyCode + 32);
         } else if (ev.keyCode === 192) {
           key = '\x1b`';
+        } else if (ev.keyCode === 190) {
+          key = '\x1b.';
         } else if (ev.keyCode >= 48 && ev.keyCode <= 57) {
           key = '\x1b' + (ev.keyCode - 48);
         }


### PR DESCRIPTION
This branch adds support for the ALT+. key combination (last argument in Bash). There are probably some other useful ALT combinations that are missing.
