### PR TITLE
add metaKey rule to event cancel function

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -5633,6 +5633,10 @@ function off(el, type, handler, capture) {
 }
 
 function cancel(ev) {
+  // if metaKey (command/apple key on Mac) is pressed then don't cancel event
+  // this makes stuff like command+L to focus URL bar work
+  if (ev.metaKey) return
+  
   if (ev.preventDefault) ev.preventDefault();
   ev.returnValue = false;
   if (ev.stopPropagation) ev.stopPropagation();


### PR DESCRIPTION
I did CMD+L in a term.js app and it didn't focus my browser URL bar, hence this PR! I am not sure if this breaks anything but it seems to work for me
