### PR TITLE
Browserify support for client (one-line patch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Christopher Jeffrey",
   "version": "0.0.4",
   "main": "./index.js",
+  "browser": "./src/term.js",
   "preferGlobal": false,
   "repository": "git://github.com/chjj/term.js.git",
   "homepage": "https://github.com/chjj/term.js",


### PR DESCRIPTION
Term.js is awesome... and well packaged. In fact it can already be used in browserify, if required as follows:

``` js
// How to load term.js in a browserify environment now
var Terminal = require('term.js/src/term');

// How to term.js in a browserify environment after this patch
var Terminal = require('term.js');
```

By specifying `browser: './src/term.js'`, browserify will load `./src/term.js` as it's main file instead of `./index.js`.
I seriously doubt anybody wants to use the connect middleware in their browser environment :)

I checked and everything else seems to work as intended.
