### PR TITLE
updated package.json allows successful npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "tags": ["tty", "terminal", "term", "xterm"],
   "engines": { "node": ">= 0.8.0" },
   "devDependencies": {
-    "express": "3.1.0",
-    "socket.io": "0.9.13",
-    "pty.js": "0.2.4"
+    "express": "3.4.4",
+    "socket.io": "0.9.16",
+    "pty.js": "0.2.7-1"
   }
 }


### PR DESCRIPTION
This `package.json` allows an `npm install`. I have no idea of the consequences of the upgraded packages, but the result functionally works for me.