### PR TITLE
Improve the heuristics of the bold broken check

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -5660,13 +5660,18 @@ function inherits(child, parent) {
 // use it in the terminal.
 function isBoldBroken(document) {
   var body = document.getElementsByTagName('body')[0];
+  var terminal = document.createElement('div');
+  terminal.className = 'terminal';
+  var line = document.createElement('div');
   var el = document.createElement('span');
   el.innerHTML = 'hello world';
-  body.appendChild(el);
+  line.appendChild(el);
+  terminal.appendChild(line);
+  body.appendChild(terminal);
   var w1 = el.scrollWidth;
   el.style.fontWeight = 'bold';
   var w2 = el.scrollWidth;
-  body.removeChild(el);
+  body.removeChild(terminal);
   return w1 !== w2;
 }
 


### PR DESCRIPTION
Putting a span straight in body is not a good check because it will only
succeed for a monospaced body font, where the monospace font selection
is more likely to be placed on `.terminal`. For better realism still,
I’ve put it as a span inside a div inside a div.terminal, which matches
what the real terminal will do, so it should be as sound a check as can
be done short of doing it on the actual terminal (though quite frankly I
don’t see why we don’t just do that).