### PR TITLE
Handle space bar key down

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2615,6 +2615,10 @@ Terminal.prototype.keyDown = function(ev) {
     case 27:
       key = '\x1b';
       break;
+    // space
+    case 32:
+      key = '\x20';
+      break;
     // left-arrow
     case 37:
       if (this.applicationCursor) {


### PR DESCRIPTION
When using the Smooth Scrolling extension for Chrome for some reason the space bar is not working. This fixes it adding support for space bar key down.

This fixes #48. Actually I just copy-pasted the code @KipSOFT posted [here](https://github.com/chjj/term.js/issues/48#issuecomment-58104360). :sparkles: