### PR TITLE
Fix weird wrapping with multiple tab stops (^I)

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2948,9 +2948,9 @@ Terminal.prototype.resize = function(x, y) {
       }
     }
   }
-  this.setupStops(j);
   this.cols = x;
   this.columns = x;
+  this.setupStops(j);
 
   // resize rows
   j = this.rows;


### PR DESCRIPTION
# Problem

Per https://github.com/f/atom-term2/issues/34

![Image of Broken Word Wrap](https://cloud.githubusercontent.com/assets/2343130/3832015/bec2d228-1d99-11e4-8890-57c6810bdc27.png)

# Solution

`term.js::resize()` was calling `setupStops()` _before_ updating `this.cols`, but `setupStops()` **uses** the value of `this.cols` to know how many tabStops to create:

```
--- term.js__ORIG	2015-09-24 18:33:45.000000000 -0400
+++ term.js	2015-09-24 18:33:53.000000000 -0400
@@ -2771,8 +2771,8 @@
       }
     }
   }
-  this.setupStops(j);
   this.cols = x;
+  this.setupStops(j);

   // resize rows
   j = this.rows;
```
