### PR TITLE
Define term.js as an AMD module when AMD is defined

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -5966,7 +5966,9 @@ Terminal.on = on;
 Terminal.off = off;
 Terminal.cancel = cancel;
 
-if (typeof module !== 'undefined') {
+if (typeof define === 'function' && define.amd) {
+  define([], function() { return Terminal; });
+} else if (typeof module !== 'undefined') {
   module.exports = Terminal;
 } else {
   this.Terminal = Terminal;


### PR DESCRIPTION
In addition to the Node style modules that term.js already supports
this commit adds support for AMD browser modules. The module usage
is auto-detected.