### PR TITLE
Remove identical if statement branches in keyDown handler

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2680,18 +2680,10 @@ Terminal.prototype.keyDown = function(ev) {
       break;
     // home
     case 36:
-      if (this.applicationKeypad) {
-        key = '\x1bOH';
-        break;
-      }
       key = '\x1bOH';
       break;
     // end
     case 35:
-      if (this.applicationKeypad) {
-        key = '\x1bOF';
-        break;
-      }
       key = '\x1bOF';
       break;
     // page up


### PR DESCRIPTION
This is a minor tweak.  These two code paths are identical, there's
no need for the if statement here.